### PR TITLE
fix "symol" misspelling

### DIFF
--- a/quanttrader/brokerage/ib_brokerage.py
+++ b/quanttrader/brokerage/ib_brokerage.py
@@ -403,7 +403,7 @@ class InteractiveBrokers(BrokerageBase):
             ib_contract.currency = 'USD'
             ib_contract.exchange = symbol_fields[2]
         elif symbol_fields[1] == 'CASH':
-            ib_contract.symol = symbol_fields[0][0:3]     # EUR
+            ib_contract.symbol = symbol_fields[0][0:3]     # EUR
             ib_contract.secType = symbol_fields[1]          # CASH
             ib_contract.currency = symbol_fields[0][3:]  # GBP
             ib_contract.exchange = symbol_fields[2]      # IDEALPRO
@@ -474,7 +474,7 @@ class InteractiveBrokers(BrokerageBase):
         if ib_contract.secType == 'STK':
             full_symbol = ' '.join([ib_contract.localSymbol, 'STK', 'SMART'])    # or ib_contract.primaryExchange?
         elif ib_contract.secType == 'CASH':
-            full_symbol = ' '.join([ib_contract.symol+ib_contract.currency, 'CASH', ib_contract.exchange])
+            full_symbol = ' '.join([ib_contract.symbol+ib_contract.currency, 'CASH', ib_contract.exchange])
         elif ib_contract.secType == 'FUT':
             full_symbol = ' '.join([ib_contract.localSymbol.replace(' ', '_'), 'FUT',
                                     ib_contract.primaryExchange if ib_contract.primaryExchange != ''


### PR DESCRIPTION
Fixes an error I had when running https://github.com/HenryFBP/algorithmic-trading/blob/master/src/algotradingtest/quanttradertest/live_engine.py

```
Exception in thread Thread-2:
Traceback (most recent call last):
  File "/usr/lib/python3.9/threading.py", line 954, in _bootstrap_inner
    self.run()
  File "/usr/lib/python3.9/threading.py", line 892, in run
    self._target(*self._args, **self._kwargs)
  File "/home/henry/.cache/pypoetry/virtualenvs/algotradingtest-zDQ7C9ry-py3.9/lib/python3.9/site-packages/ibapi/client.py", line 263, in run
    self.decoder.interpret(fields)
  File "/home/henry/.cache/pypoetry/virtualenvs/algotradingtest-zDQ7C9ry-py3.9/lib/python3.9/site-packages/ibapi/decoder.py", line 1296, in interpret
    handleInfo.processMeth(self, iter(fields))
  File "/home/henry/.cache/pypoetry/virtualenvs/algotradingtest-zDQ7C9ry-py3.9/lib/python3.9/site-packages/ibapi/decoder.py", line 255, in processPortfolioValueMsg
    self.wrapper.updatePortfolio( contract,
  File "/home/henry/.cache/pypoetry/virtualenvs/algotradingtest-zDQ7C9ry-py3.9/lib/python3.9/site-packages/quanttrader/brokerage/ib_brokerage.py", line 768, in updatePortfolio
    position_event.full_symbol = InteractiveBrokers.contract_to_symbol(contract)
  File "/home/henry/.cache/pypoetry/virtualenvs/algotradingtest-zDQ7C9ry-py3.9/lib/python3.9/site-packages/quanttrader/brokerage/ib_brokerage.py", line 477, in contract_to_symbol
    full_symbol = ' '.join([ib_contract.symol+ib_contract.currency, 'CASH', ib_contract.exchange])
AttributeError: 'Contract' object has no attribute 'symol'
```